### PR TITLE
Ubuntu20Preconfig Script Fix

### DIFF
--- a/ubuntu20-preconfig.sh
+++ b/ubuntu20-preconfig.sh
@@ -294,7 +294,7 @@ add_cockpit() {
 	fi
 	
 	apt install -y cockpit cockpit-benchmark cockpit-navigator cockpit-file-sharing cockpit-45drives-hardware cockpit-identities  \
-		cockpit-sosreport realmd tuned udisks2-lvm2 zfs-dkms samba winbind nfs-kernel-server nfs-client 45drives-tools cockpit-scheduler cockpit-zfs nano tuned 
+		realmd tuned udisks2-lvm2 zfs-dkms samba winbind nfs-kernel-server nfs-client 45drives-tools cockpit-scheduler cockpit-zfs nano tuned 
 	
     res=$?
 	


### PR DESCRIPTION
Asked to investigate NCR 355616; Ubuntu20Preconfig script would fail on installing Cockpit modules.
Found that the cause was ubuntu-sosreport being added as a package to be installed. 
This package isn't present in our Focal repo.
Removed the package from the script to resolve the issue.